### PR TITLE
Enhance mapper to provide better reporting on consecutive failures

### DIFF
--- a/piri/mapper.py
+++ b/piri/mapper.py
@@ -42,9 +42,18 @@ def map_data(
     )
 
     if not is_successful(iterate_data):
-        return map_object(input_data, configuration).map(
+        error_message = iterate_data.failure()
+
+        mapped_object = map_object(input_data, configuration).map(
             partial(set_array, array=configuration[ARRAY]),
-        ).unwrap()
+        )
+
+        # When Failure happens on the previous Failure, the previous exception
+        # will get swallowed.
+        if not is_successful(mapped_object):
+            raise Exception(error_message)
+
+        return mapped_object.unwrap()
 
     mapped_objects: List[dict] = []
 

--- a/piri/mapper.py
+++ b/piri/mapper.py
@@ -42,9 +42,12 @@ def map_data(
     )
 
     if not is_successful(iterate_data):
-        error_message = iterate_data.failure()
+        error_message: Exception = iterate_data.failure()
 
-        mapped_object = map_object(input_data, configuration).map(
+        mapped_object = map_object(  # type: ignore
+            input_data,
+            configuration,
+        ).map(
             partial(set_array, array=configuration[ARRAY]),
         )
 


### PR DESCRIPTION
@thomasborgen The issue was that in the second phase object may be of type `_Nothing` which is inconvenient to work with, so I "cache" an error and on the 2nd failure return it.