### PR TITLE
adds requirements file for ReadTheDocs build

### DIFF
--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material


### PR DESCRIPTION
adding rtd_requirements.txt in root with 'mkdocs-material' was all that was needed to build the docs.