### PR TITLE
add test to test precision of casting to decimal

### DIFF
--- a/tests/casting/test_cast_to_decimal.py
+++ b/tests/casting/test_cast_to_decimal.py
@@ -75,3 +75,10 @@ def test_abc_with_decimal_argument_fails():
     assert not is_successful(test)
     assert isinstance(test.failure(), ValueError)
     assert 'Illegal characters in value' in str(test.failure())
+
+
+def test_precision_is_maintained():
+    """Test high precision decimal value with one period."""
+    assert CastToDecimal()(
+        '1234567.89123456789',
+    ).unwrap() == Decimal('1234567.89123456789')


### PR DESCRIPTION
A simple test to prove that casting to a decimal doesn't lose precision. This fixes https://github.com/greenbird/piri/issues/81